### PR TITLE
14409 dark theme impacts color of drop downs in work package table

### DIFF
--- a/app/assets/stylesheets/dark/_variables.css.sass
+++ b/app/assets/stylesheets/dark/_variables.css.sass
@@ -39,3 +39,9 @@ $main_menu_sidebar_font_color:                  #FFFFFF
 $main_menu_sidebar_h3_color:                    #FFFFFF
 $main_menu_sidebar_link_color:                  #FFFFFF
 $main_menu_enable_toggle_highlighting:          true
+
+$drop_down_unselected_font_color:               #333333
+$drop_down_selected_font_color:                 #BBBBBB
+$drop_down_selected_bg_color:                   #053242
+
+$context_menu_font_color:                       #333333


### PR DESCRIPTION
[`* `#14409` Dark theme impacts color of drop downs in work package table`](https://community.openproject.org/work_packages/14409)

:exclamation: Depends on Core PR https://github.com/opf/openproject/pull/2046
