### PR TITLE
Set toggle separator color

### DIFF
--- a/app/assets/stylesheets/dark/_variables.sass
+++ b/app/assets/stylesheets/dark/_variables.sass
@@ -39,6 +39,8 @@ $main-menu-bg-hover-selected-background:        #04232f
 $main-menu-font-color:                          white
 $main-menu-selected-hover-indicator-color:      white
 
+$main-menu-toggler-separator-color:             #FFFFFF
+
 $main-menu-sidebar-font-color:                  #FFFFFF
 $main-menu-sidebar-h3-color:                    #FFFFFF
 $main-menu-sidebar-link-color:                  #FFFFFF


### PR DESCRIPTION
https://github.com/opf/openproject/pull/4227 introduces a line separator for toggle arrows in the menu sidebar. This PR sets the according color.

https://community.openproject.org/work_packages/22845/activity
